### PR TITLE
Added support for Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj
+xcuserdata/
+DerivedData/
+.swiftpm/config/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "DTFoundation",
+        "repositoryURL": "https://github.com/Cocoanetics/DTFoundation",
+        "state": {
+          "branch": null,
+          "revision": "76062513434421cb6c8a1ae1d4f8368a7ebc2da3",
+          "version": "1.7.18"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.2
+import PackageDescription
+
+let package = Package(
+    name: "TCMobileProvision",
+    products: [
+        .library(
+            name: "TCMobileProvision",
+            targets: ["TCMobileProvision"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Cocoanetics/DTFoundation", .upToNextMinor(from: "1.7.0"))
+    ],
+    targets: [
+        .target(
+            name: "TCMobileProvision",
+            dependencies: ["DTFoundation"],
+            path: "Sources/iOS",
+            publicHeadersPath: ""
+       )
+    ]
+)

--- a/Sources/iOS/TCMobileProvision.m
+++ b/Sources/iOS/TCMobileProvision.m
@@ -15,7 +15,7 @@
  */
 
 #import "TCMobileProvision.h"
-#import "DTASN1Parser.h"
+#import <DTFoundation/DTASN1Parser.h>
 
 @interface TCMobileProvision () <DTASN1ParserDelegate>
 


### PR DESCRIPTION
The PR enables Swift Package Manager support for TCMobileProvision. 

Note: Right now you need to point SPM to the `master` branch. We probably want to move the tag 1.0.0 to point to this branch so Xcode can easily pick up the changes.

I tested the CocoaPods still works, but please make sure that both package managers are working on this branch before merging.